### PR TITLE
Chore/tests-and-refactor-1

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -65,6 +65,7 @@
         "stop_token": "cpp",
         "streambuf": "cpp",
         "thread": "cpp",
-        "variant": "cpp"
+        "variant": "cpp",
+        "cassert": "cpp"
     }
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,4 +12,4 @@ add_subdirectory(DuplicationDetection)
 # Register tests for each module
 register_module_tests(reader ${CMAKE_CURRENT_SOURCE_DIR}/Reader)
 register_module_tests(segment ${CMAKE_CURRENT_SOURCE_DIR}/Segment)
-register_module_tests(duplication_detection ${CMAKE_CURRENT_SOURCE_DIR}/DuplicationDetection)
+register_module_tests(duplication_detection ${CMAKE_CURRENT_SOURCE_DIR}/DuplicationDetection ${CMAKE_CURRENT_SOURCE_DIR}/Segment)

--- a/src/DuplicationDetection/SegmentMerger.cpp
+++ b/src/DuplicationDetection/SegmentMerger.cpp
@@ -1,13 +1,12 @@
 #include "SegmentMerger.hpp"
+#include <cassert>
 
 using namespace MyNetwork;
 
-// TODO: tests
-
 Segment SegmentMerger::intersect_segment(const Segment &s1, const Segment &s2) const
 {
-    // TODO: assert
-    // assumption contiguous: s1 < s2 and same location (postal + street + parity)
+    assert(has_intersection(s1, s2));
+
     Segment result{s2};
     result.to_street_number = s1.to_street_number;
     result.from_street_number = s2.from_street_number;
@@ -17,8 +16,7 @@ Segment SegmentMerger::intersect_segment(const Segment &s1, const Segment &s2) c
 Segment SegmentMerger::union_segment(const Segment &s1, const Segment &s2) const
 {
 
-    // TODO: assert
-    // assumption contiguous s1 < s2 and same location (postal + street + parity)
+    assert(is_contiguous(s1, s2));
     Segment result{s1};
     result.to_street_number = s2.to_street_number;
     return result;
@@ -34,15 +32,12 @@ int one_less_from_number(const Segment &s)
 
 bool SegmentMerger::is_contiguous(const Segment &s1, const Segment &s2) const
 {
-    // TODO: assert
-    // assumption, s1 < s2 and same location (postal + street + parity)
     return s1.postal_code == s2.postal_code && s1.STREET_NAME_AND_TYPE == s2.STREET_NAME_AND_TYPE && s1.parity == s2.parity &&
            one_less_from_number(s2) <= s1.to_street_number;
 }
 
 bool SegmentMerger::has_intersection(const Segment &s1, const Segment &s2) const
 {
-    // TODO: assert
-    // assumption, s1 < s2 and same location (postal + street + parity)
+    assert(s1 <= s2 && is_contiguous(s1, s2));
     return s2.from_street_number <= s1.to_street_number;
 }

--- a/src/DuplicationDetection/SegmentMerger.cpp
+++ b/src/DuplicationDetection/SegmentMerger.cpp
@@ -9,8 +9,8 @@ Segment SegmentMerger::intersect_segment(const Segment &s1, const Segment &s2) c
     assert(has_intersection(s1, s2));
 
     Segment result{s2};
-    result.from_street_number = std::max(s1.from_street_number, s2.from_street_number);
-    result.to_street_number = std::min(s1.to_street_number, s2.to_street_number);
+    result.to_street_number = s1.to_street_number;
+    result.from_street_number = s2.from_street_number;
     return result;
 }
 
@@ -19,8 +19,7 @@ Segment SegmentMerger::union_segment(const Segment &s1, const Segment &s2) const
 
     assert(is_contiguous(s1, s2));
     Segment result{s1};
-    result.from_street_number = std::min(s1.from_street_number, s2.from_street_number);
-    result.to_street_number = std::max(s1.to_street_number, s2.to_street_number);
+    result.to_street_number = s2.to_street_number;
     return result;
 }
 

--- a/src/DuplicationDetection/SegmentMerger.cpp
+++ b/src/DuplicationDetection/SegmentMerger.cpp
@@ -1,5 +1,6 @@
 #include "SegmentMerger.hpp"
 #include <cassert>
+#include <algorithm>
 
 using namespace MyNetwork;
 
@@ -8,8 +9,8 @@ Segment SegmentMerger::intersect_segment(const Segment &s1, const Segment &s2) c
     assert(has_intersection(s1, s2));
 
     Segment result{s2};
-    result.to_street_number = s1.to_street_number;
-    result.from_street_number = s2.from_street_number;
+    result.from_street_number = std::max(s1.from_street_number, s2.from_street_number);
+    result.to_street_number = std::min(s1.to_street_number, s2.to_street_number);
     return result;
 }
 
@@ -18,7 +19,8 @@ Segment SegmentMerger::union_segment(const Segment &s1, const Segment &s2) const
 
     assert(is_contiguous(s1, s2));
     Segment result{s1};
-    result.to_street_number = s2.to_street_number;
+    result.from_street_number = std::min(s1.from_street_number, s2.from_street_number);
+    result.to_street_number = std::max(s1.to_street_number, s2.to_street_number);
     return result;
 }
 

--- a/src/DuplicationDetection/__tests__/SegmentMerger_tests.cpp
+++ b/src/DuplicationDetection/__tests__/SegmentMerger_tests.cpp
@@ -22,10 +22,16 @@ TEST(SegmentMergerTest, IntersectSegment)
 {
     SegmentMerger merger;
     Segment base = create_segment(Parity::Even, 2, 10);
+
     Segment overlapping = create_segment(Parity::Even, 8, 20);
     Segment overlapping_result = merger.intersect_segment(base, overlapping);
     test_same_base_properties(base, overlapping_result);
     test_from_to_properties(overlapping_result, 8, 10);
+
+    Segment fully_included = create_segment(Parity::Even, 4, 6);
+    Segment fully_included_result = merger.intersect_segment(base, fully_included);
+    test_same_base_properties(base, fully_included_result);
+    test_from_to_properties(fully_included_result, 4, 6);
 
     Segment tangent = create_segment(Parity::Even, 10, 16);
     Segment tangent_result = merger.intersect_segment(base, tangent);
@@ -37,6 +43,17 @@ TEST(SegmentMergerTest, UnionSegment)
 {
     SegmentMerger merger;
     Segment base = create_segment(Parity::Even, 2, 10);
+
+    Segment same = create_segment(Parity::Even, 2, 10);
+    Segment same_result = merger.union_segment(base, same);
+    test_same_base_properties(base, same_result);
+    test_from_to_properties(same_result, 2, 10);
+
+    Segment fully_included = create_segment(Parity::Even, 4, 6);
+    Segment fully_included_result = merger.union_segment(base, fully_included);
+    test_same_base_properties(base, fully_included_result);
+    test_from_to_properties(fully_included_result, 2, 10);
+
     Segment overlapping = create_segment(Parity::Even, 8, 20);
     Segment overlapping_result = merger.union_segment(base, overlapping);
     test_same_base_properties(base, overlapping_result);
@@ -56,24 +73,49 @@ TEST(SegmentMergerTest, UnionSegment)
 TEST(SegmentMergerTest, IsContiguousEven)
 {
     SegmentMerger merger;
-    Segment s1 = create_segment(Parity::Even, 2, 10);
-    Segment s2 = create_segment(Parity::Even, 12, 20);
-    // s2.from_street_number - 2 == 10
-    EXPECT_TRUE(merger.is_contiguous(s1, s2));
-    // Not contiguous
-    Segment s3 = create_segment(Parity::Even, 14, 20);
-    EXPECT_FALSE(merger.is_contiguous(s1, s3));
+    Segment base = create_segment(Parity::Even, 2, 10);
+
+    Segment same = create_segment(Parity::Even, 2, 10);
+    EXPECT_TRUE(merger.is_contiguous(base, same));
+
+    Segment fully_included = create_segment(Parity::Even, 4, 8);
+    EXPECT_TRUE(merger.is_contiguous(base, fully_included));
+
+    Segment tangent = create_segment(Parity::Even, 10, 16);
+    EXPECT_TRUE(merger.is_contiguous(base, tangent));
+
+    Segment adjacent = create_segment(Parity::Even, 12, 20);
+    EXPECT_TRUE(merger.is_contiguous(base, adjacent));
+
+    Segment overlapping = create_segment(Parity::Even, 6, 16);
+    EXPECT_TRUE(merger.is_contiguous(base, overlapping));
+
+    Segment far = create_segment(Parity::Even, 14, 20);
+    EXPECT_FALSE(merger.is_contiguous(base, far));
 }
 
 TEST(SegmentMergerTest, IsContiguousMixed)
 {
     SegmentMerger merger;
-    Segment s1 = create_segment(Parity::Mixed, 1, 10);
-    Segment s2 = create_segment(Parity::Mixed, 11, 20);
-    // s2.from_street_number - 1 == 10
-    EXPECT_TRUE(merger.is_contiguous(s1, s2));
-    Segment s3 = create_segment(Parity::Mixed, 12, 20);
-    EXPECT_FALSE(merger.is_contiguous(s1, s3));
+    Segment base = create_segment(Parity::Mixed, 2, 9);
+
+    Segment same = create_segment(Parity::Mixed, 2, 9);
+    EXPECT_TRUE(merger.is_contiguous(base, same));
+
+    Segment fully_included = create_segment(Parity::Mixed, 4, 8);
+    EXPECT_TRUE(merger.is_contiguous(base, fully_included));
+
+    Segment tangent = create_segment(Parity::Mixed, 9, 14);
+    EXPECT_TRUE(merger.is_contiguous(base, tangent));
+
+    Segment adjacent = create_segment(Parity::Mixed, 10, 20);
+    EXPECT_TRUE(merger.is_contiguous(base, adjacent));
+
+    Segment overlapping = create_segment(Parity::Mixed, 6, 16);
+    EXPECT_TRUE(merger.is_contiguous(base, overlapping));
+
+    Segment far = create_segment(Parity::Mixed, 11, 20);
+    EXPECT_FALSE(merger.is_contiguous(base, far));
 }
 
 TEST(SegmentMergerTest, IsContiguousDifferentLocation)
@@ -91,9 +133,22 @@ TEST(SegmentMergerTest, IsContiguousDifferentLocation)
 TEST(SegmentMergerTest, HasIntersection)
 {
     SegmentMerger merger;
-    Segment s1 = create_segment(Parity::Even, 2, 10);
-    Segment s2 = create_segment(Parity::Even, 8, 20);
-    EXPECT_TRUE(merger.has_intersection(s1, s2));
-    Segment s3 = create_segment(Parity::Even, 12, 20);
-    EXPECT_FALSE(merger.has_intersection(s1, s3));
+    Segment base = create_segment(Parity::Even, 2, 10);
+
+    Segment same = create_segment(Parity::Even, 2, 10);
+    EXPECT_TRUE(merger.has_intersection(base, same));
+
+    Segment fully_included = create_segment(Parity::Even, 4, 8);
+    EXPECT_TRUE(merger.has_intersection(base, fully_included));
+
+    Segment overlapping = create_segment(Parity::Even, 8, 20);
+    EXPECT_TRUE(merger.has_intersection(base, overlapping));
+
+    Segment tangent = create_segment(Parity::Even, 10, 16);
+    EXPECT_TRUE(merger.has_intersection(base, tangent));
+
+    Segment adjacent = create_segment(Parity::Even, 12, 20);
+    EXPECT_FALSE(merger.has_intersection(base, adjacent));
+
+    // far: 14-20 can't be as it's not contiguous with base
 }

--- a/src/DuplicationDetection/__tests__/SegmentMerger_tests.cpp
+++ b/src/DuplicationDetection/__tests__/SegmentMerger_tests.cpp
@@ -1,0 +1,99 @@
+#include "gtest/gtest.h"
+#include "SegmentMerger.hpp"
+#include "NetworkSegment.hpp"
+#include "Segment/__tests__/TestSegment.hpp"
+
+using namespace MyNetwork;
+
+void test_same_base_properties(const Segment &s1, const Segment &s2)
+{
+    EXPECT_EQ(s1.postal_code, s2.postal_code);
+    EXPECT_EQ(s1.STREET_NAME_AND_TYPE, s2.STREET_NAME_AND_TYPE);
+    EXPECT_EQ(s1.parity, s2.parity);
+}
+
+void test_from_to_properties(const Segment &s, int expected_from, int expected_to)
+{
+    EXPECT_EQ(s.from_street_number, expected_from);
+    EXPECT_EQ(s.to_street_number, expected_to);
+}
+
+TEST(SegmentMergerTest, IntersectSegment)
+{
+    SegmentMerger merger;
+    Segment base = create_segment(Parity::Even, 2, 10);
+    Segment overlapping = create_segment(Parity::Even, 8, 20);
+    Segment overlapping_result = merger.intersect_segment(base, overlapping);
+    test_same_base_properties(base, overlapping_result);
+    test_from_to_properties(overlapping_result, 8, 10);
+
+    Segment tangent = create_segment(Parity::Even, 10, 16);
+    Segment tangent_result = merger.intersect_segment(base, tangent);
+    test_same_base_properties(base, tangent_result);
+    test_from_to_properties(tangent_result, 10, 10);
+}
+
+TEST(SegmentMergerTest, UnionSegment)
+{
+    SegmentMerger merger;
+    Segment base = create_segment(Parity::Even, 2, 10);
+    Segment overlapping = create_segment(Parity::Even, 8, 20);
+    Segment overlapping_result = merger.union_segment(base, overlapping);
+    test_same_base_properties(base, overlapping_result);
+    test_from_to_properties(overlapping_result, 2, 20);
+
+    Segment tangent = create_segment(Parity::Even, 10, 16);
+    Segment tangent_result = merger.union_segment(base, tangent);
+    test_same_base_properties(base, tangent_result);
+    test_from_to_properties(tangent_result, 2, 16);
+
+    Segment adjacent = create_segment(Parity::Even, 12, 32);
+    Segment adjacent_result = merger.union_segment(base, adjacent);
+    test_same_base_properties(base, adjacent_result);
+    test_from_to_properties(adjacent_result, 2, 32);
+}
+
+TEST(SegmentMergerTest, IsContiguousEven)
+{
+    SegmentMerger merger;
+    Segment s1 = create_segment(Parity::Even, 2, 10);
+    Segment s2 = create_segment(Parity::Even, 12, 20);
+    // s2.from_street_number - 2 == 10
+    EXPECT_TRUE(merger.is_contiguous(s1, s2));
+    // Not contiguous
+    Segment s3 = create_segment(Parity::Even, 14, 20);
+    EXPECT_FALSE(merger.is_contiguous(s1, s3));
+}
+
+TEST(SegmentMergerTest, IsContiguousMixed)
+{
+    SegmentMerger merger;
+    Segment s1 = create_segment(Parity::Mixed, 1, 10);
+    Segment s2 = create_segment(Parity::Mixed, 11, 20);
+    // s2.from_street_number - 1 == 10
+    EXPECT_TRUE(merger.is_contiguous(s1, s2));
+    Segment s3 = create_segment(Parity::Mixed, 12, 20);
+    EXPECT_FALSE(merger.is_contiguous(s1, s3));
+}
+
+TEST(SegmentMergerTest, IsContiguousDifferentLocation)
+{
+    SegmentMerger merger;
+    Segment base_segment = create_segment(Parity::Even, 2, 10, "1045", "Kossuth utca");
+    Segment different_street = create_segment(Parity::Even, 12, 20, "1045", "Petőfi utca");
+    EXPECT_FALSE(merger.is_contiguous(base_segment, different_street));
+    Segment different_postal_code = create_segment(Parity::Even, 12, 20, "4046", "Kossuth utca");
+    EXPECT_FALSE(merger.is_contiguous(base_segment, different_postal_code));
+    Segment different_parity = create_segment(Parity::Odd, 11, 21, "1045", "Kossuth utca");
+    EXPECT_FALSE(merger.is_contiguous(base_segment, different_parity));
+}
+
+TEST(SegmentMergerTest, HasIntersection)
+{
+    SegmentMerger merger;
+    Segment s1 = create_segment(Parity::Even, 2, 10);
+    Segment s2 = create_segment(Parity::Even, 8, 20);
+    EXPECT_TRUE(merger.has_intersection(s1, s2));
+    Segment s3 = create_segment(Parity::Even, 12, 20);
+    EXPECT_FALSE(merger.has_intersection(s1, s3));
+}

--- a/src/DuplicationDetection/__tests__/SegmentMerger_tests.cpp
+++ b/src/DuplicationDetection/__tests__/SegmentMerger_tests.cpp
@@ -28,11 +28,6 @@ TEST(SegmentMergerTest, IntersectSegment)
     test_same_base_properties(base, overlapping_result);
     test_from_to_properties(overlapping_result, 8, 10);
 
-    Segment fully_included = create_segment(Parity::Even, 4, 6);
-    Segment fully_included_result = merger.intersect_segment(base, fully_included);
-    test_same_base_properties(base, fully_included_result);
-    test_from_to_properties(fully_included_result, 4, 6);
-
     Segment tangent = create_segment(Parity::Even, 10, 16);
     Segment tangent_result = merger.intersect_segment(base, tangent);
     test_same_base_properties(base, tangent_result);
@@ -48,11 +43,6 @@ TEST(SegmentMergerTest, UnionSegment)
     Segment same_result = merger.union_segment(base, same);
     test_same_base_properties(base, same_result);
     test_from_to_properties(same_result, 2, 10);
-
-    Segment fully_included = create_segment(Parity::Even, 4, 6);
-    Segment fully_included_result = merger.union_segment(base, fully_included);
-    test_same_base_properties(base, fully_included_result);
-    test_from_to_properties(fully_included_result, 2, 10);
 
     Segment overlapping = create_segment(Parity::Even, 8, 20);
     Segment overlapping_result = merger.union_segment(base, overlapping);

--- a/src/Segment/NetworkSegment.hpp
+++ b/src/Segment/NetworkSegment.hpp
@@ -3,8 +3,6 @@
 #include <vector>
 #include <string>
 
-// TODO: use forward iterator instead of vector
-
 namespace MyNetwork
 {
     enum class Parity
@@ -18,12 +16,14 @@ namespace MyNetwork
 
     struct Segment
     {
-        decltype(NetworkRecord::L_POSTAL_CODE) postal_code;
+        std::string postal_code;
         std::string STREET_NAME_AND_TYPE;
         Parity parity;
-        decltype(NetworkRecord::FROMLEFT) from_street_number;
-        decltype(NetworkRecord::TOLEFT) to_street_number;
+        int from_street_number;
+        int to_street_number;
+
+        auto operator<=>(const MyNetwork::Segment &) const = default;
     };
 }
 
-std::ostream& operator<<(std::ostream& os, const MyNetwork::Segment&);
+std::ostream &operator<<(std::ostream &os, const MyNetwork::Segment &);

--- a/src/Segment/__tests__/NetworkSegment_tests.cpp
+++ b/src/Segment/__tests__/NetworkSegment_tests.cpp
@@ -1,31 +1,82 @@
 #include <gtest/gtest.h>
 #include "NetworkSegment.hpp"
-#include <stdexcept>
+#include "TestSegment.hpp"
+#include <sstream>
+#include <string>
 
-using MyNetwork::is_valid_parity;
+using namespace MyNetwork;
 
 TEST(NetworkSegmentTest, ReturnTrueForValidParityChars)
 {
-
-    EXPECT_EQ(is_valid_parity('O'), true);
-    EXPECT_EQ(is_valid_parity('E'), true);
-    EXPECT_EQ(is_valid_parity('M'), true);
+    EXPECT_TRUE(is_valid_parity('O'));
+    EXPECT_TRUE(is_valid_parity('E'));
+    EXPECT_TRUE(is_valid_parity('M'));
 }
 
 TEST(NetworkSegmentTest, ReturnFalseForInvalidParityChars)
 {
-    EXPECT_EQ(is_valid_parity('\0'), false);
-    EXPECT_EQ(is_valid_parity(' '), false);
-    EXPECT_EQ(is_valid_parity('o'), false);
-    EXPECT_EQ(is_valid_parity('e'), false);
-    EXPECT_EQ(is_valid_parity('m'), false);
-    EXPECT_EQ(is_valid_parity('A'), false);
-    EXPECT_EQ(is_valid_parity('z'), false);
+    EXPECT_FALSE(is_valid_parity('\0'));
+    EXPECT_FALSE(is_valid_parity(' '));
+    EXPECT_FALSE(is_valid_parity('o'));
+    EXPECT_FALSE(is_valid_parity('e'));
+    EXPECT_FALSE(is_valid_parity('m'));
+    EXPECT_FALSE(is_valid_parity('A'));
+    EXPECT_FALSE(is_valid_parity('z'));
 }
 
 TEST(NetworkSegmentTest, CastValidParityChars)
 {
-    EXPECT_EQ(static_cast<MyNetwork::Parity>('O'), MyNetwork::Parity::Odd);
-    EXPECT_EQ(static_cast<MyNetwork::Parity>('E'), MyNetwork::Parity::Even);
-    EXPECT_EQ(static_cast<MyNetwork::Parity>('M'), MyNetwork::Parity::Mixed);
+    EXPECT_EQ(static_cast<Parity>('O'), Parity::Odd);
+    EXPECT_EQ(static_cast<Parity>('E'), Parity::Even);
+    EXPECT_EQ(static_cast<Parity>('M'), Parity::Mixed);
+}
+
+TEST(NetworkSegmentTest, OstreamOperator)
+{
+    Segment s = create_segment(Parity::Odd, 1, 9);
+    std::ostringstream oss;
+    oss << s;
+    std::string out = oss.str();
+    EXPECT_NE(out.find("Kossuth utca"), std::string::npos);
+    EXPECT_NE(out.find("O"), std::string::npos);
+    EXPECT_NE(out.find("1"), std::string::npos);
+    EXPECT_NE(out.find("9"), std::string::npos);
+}
+
+TEST(NetworkSegmentTest, OperatorEqualsAndNotEquals)
+{
+    Segment s1 = create_segment(Parity::Odd, 1, 9);
+    Segment s2 = create_segment(Parity::Odd, 1, 9);
+    Segment s3 = create_segment(Parity::Even, 2, 10);
+    EXPECT_TRUE(s1 == s2);
+    EXPECT_FALSE(s1 != s2);
+    EXPECT_FALSE(s1 == s3);
+    EXPECT_TRUE(s1 != s3);
+}
+
+TEST(NetworkSegmentTest, OperatorLessEqual)
+{
+    Segment base_segment = create_segment(Parity::Odd, 1, 9);
+    Segment totally_equal = create_segment(Parity::Odd, 1, 9);
+    Segment greater_from = create_segment(Parity::Odd, 3, 9);
+    Segment greater_to = create_segment(Parity::Odd, 1, 11);
+    Segment greater_street = create_segment(Parity::Odd, 1, 7, "1045", "Petőfi utca");
+    Segment greater_postal_code = create_segment(Parity::Odd, 1, 7, "1046", "Aladár utca");
+    EXPECT_TRUE(base_segment <= totally_equal);
+    EXPECT_TRUE(base_segment <= greater_from);
+    EXPECT_TRUE(base_segment <= greater_to);
+    EXPECT_TRUE(base_segment <= greater_street);
+    EXPECT_TRUE(base_segment <= greater_postal_code);
+    Segment less_from = create_segment(Parity::Odd, 1, 7);
+    EXPECT_FALSE(base_segment <= less_from);
+}
+
+TEST(NetworkSegmentTest, OperatorLess)
+{
+    Segment s1 = create_segment(Parity::Odd, 1, 9);
+    Segment s2 = create_segment(Parity::Odd, 1, 11);
+    Segment s3 = create_segment(Parity::Odd, 1, 9);
+    EXPECT_TRUE(s1 < s2);
+    EXPECT_FALSE(s1 < s3);
+    EXPECT_FALSE(s2 < s1);
 }

--- a/src/Segment/__tests__/TestSegment.cpp
+++ b/src/Segment/__tests__/TestSegment.cpp
@@ -1,0 +1,18 @@
+#include "TestSegment.hpp"
+#include <cassert>
+
+using namespace MyNetwork;
+
+Segment create_segment(Parity parity, int from, int to, std::string postal, std::string street)
+{
+    assert(parity == MyNetwork::Parity::Even ? from % 2 == 0 && to % 2 == 0 : true);
+    assert(parity == MyNetwork::Parity::Odd ? from % 2 == 1 && to % 2 == 1 : true);
+
+    MyNetwork::Segment s;
+    s.postal_code = postal;
+    s.STREET_NAME_AND_TYPE = street;
+    s.parity = parity;
+    s.from_street_number = from;
+    s.to_street_number = to;
+    return s;
+}

--- a/src/Segment/__tests__/TestSegment.hpp
+++ b/src/Segment/__tests__/TestSegment.hpp
@@ -1,0 +1,3 @@
+#include "NetworkSegment.hpp"
+
+MyNetwork::Segment create_segment(MyNetwork::Parity parity, int from, int to, std::string postal = "1045", std::string street = "Kossuth utca");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -31,7 +31,7 @@ std::optional<Segment> detect_duplicates(const SegmentMerger &segment_merger, Se
     }
 
     // No duplicate
-    return std::optional<Segment>{};
+    return {};
 }
 
 std::vector<Segment> get_sorted_segments(const std::vector<MyNetwork::NetworkRecord> &data)
@@ -45,22 +45,7 @@ std::vector<Segment> get_sorted_segments(const std::vector<MyNetwork::NetworkRec
         auto segments = segment_mapper.map_from_record(nw);
         std::copy(segments.begin(), segments.end(), std::back_inserter(sv)); });
 
-    std::sort(sv.begin(), sv.end(), [](const Segment &s1, const Segment &s2)
-              {
-        if (s1.postal_code != s2.postal_code)
-            return s1.postal_code < s2.postal_code;
-
-        if (s1.STREET_NAME_AND_TYPE != s2.STREET_NAME_AND_TYPE)
-            return s1.STREET_NAME_AND_TYPE < s2.STREET_NAME_AND_TYPE;
-
-        if (s1.parity != s2.parity)
-            return s1.parity < s2.parity;
-
-        if (s1.from_street_number != s2.from_street_number)
-            return s1.from_street_number < s2.from_street_number;
-
-        
-            return s1.to_street_number < s2.to_street_number; });
+    std::sort(sv.begin(), sv.end());
 
     return sv;
 }

--- a/src/test_helpers.cmake
+++ b/src/test_helpers.cmake
@@ -6,10 +6,20 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(googletest)
 
 function(register_module_tests module_name module_dir)
+    set(optional_extra_test_deps ${ARGV2})  # get the 3rd argument manually (if provided)
+
     file(GLOB_RECURSE TEST_SOURCES CONFIGURE_DEPENDS
         "${module_dir}/*__tests__/*.cpp"
         "${module_dir}/**/*__tests__*/*.cpp"
     )
+
+    if(optional_extra_test_deps)
+        file(GLOB_RECURSE EXTRA_TEST_SOURCES CONFIGURE_DEPENDS
+            "${optional_extra_test_deps}/*__tests__/*.cpp"
+            "${optional_extra_test_deps}/**/*__tests__*/*.cpp"
+        )
+        list(APPEND TEST_SOURCES ${EXTRA_TEST_SOURCES})
+    endif()
 
     if(TEST_SOURCES)
         set(target_name "${module_name}_tests")


### PR DESCRIPTION
- CMake: a feature can import test helpers from another feature (Duplication uses Segment, so its test can import Segment's `create_segment` function)
- add asserts to SegmentMerger
- add tests to SegmentMerger
- generate comparison operator for Segment with compiler (spaceship operator)
  - in main.cpp general `<` operator is used for std::sort
  - extend NetworkSegment tests